### PR TITLE
_replay and ./main requires "$@" as well

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -171,7 +171,7 @@ function _replay() {
   cd $RRMODULES/$name
   modpull $name
 
-  ./main $* || {
+  ./main "$@" || {
     log $name failed
     exit 2
   }
@@ -186,7 +186,7 @@ function _require() {
 
   checkloaded $name && return 0
   markloaded $name || exit 1
-  _replay $name $*
+  _replay $name "$@"
 }
 
 test "${RRDEBUG:-0}" -gt 0 && set -x


### PR DESCRIPTION
in order to pass one argument with spaces, `"$@"` is required in the syntax instead of `$*`