### PR TITLE
Fix modpull bug

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -115,7 +115,7 @@ function modpull() {
     git pull --quiet --ff-only --rebase
   } || { git fetch --quiet origin master >/dev/null 2>&1
          git rebase --quiet origin master >/dev/null 2>&1
-       } || git fetch origin
+       } || git fetch --quiet origin >/dev/null
 }
 
 # include config files for module

--- a/lib.sh
+++ b/lib.sh
@@ -111,8 +111,12 @@ function modpull() {
   test x${RRMODDELA} = xTRUE && sleep $[ ( $RANDOM % 5 ) + 5 ]s
 
   logvvv git remote -v
-
-  git clone ${BRANCH_SWITCH} -q $repourl $name >/dev/null 2>&1
+  
+  test -z "${BRANCH_SWITCH}" && {
+    git pull --quiet --ff-only --rebase
+  } || { git fetch --quiet origin master >/dev/null 2>&1
+         git rebase --quiet origin master >/dev/null
+       }
 }
 
 # include config files for module

--- a/lib.sh
+++ b/lib.sh
@@ -103,6 +103,7 @@ test ${RRTRACEMINE} -eq 1 -a $# -lt 1 && {
 
 # do a git pull on a module
 function modpull() {
+  local default_branch="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
   test x${RRMODPULL} = xnever && return 0
   local localpull="RRMODPULL_${1//-/_}"
   localpull="${localpull//\./_}"
@@ -113,12 +114,9 @@ function modpull() {
   
   test -z "${BRANCH_SWITCH}" && {
     git pull --quiet --ff-only --rebase
-  } || { git fetch --quiet origin master >/dev/null 2>&1
-         git rebase --quiet origin master >/dev/null 2>&1
-       } || {
-             git fetch --quiet origin main >/dev/null 2>&1
-             git rebase --quiet origin main >/dev/null 2>&1
-             } || git fetch --quiet origin >/dev/null
+  } || { git fetch --quiet origin "$default_branch" >/dev/null 2>&1
+         git rebase --quiet origin "$default_branch" >/dev/null 2>&1
+       } || git fetch --quiet origin >/dev/null
 }
 
 # include config files for module

--- a/lib.sh
+++ b/lib.sh
@@ -115,7 +115,10 @@ function modpull() {
     git pull --quiet --ff-only --rebase
   } || { git fetch --quiet origin master >/dev/null 2>&1
          git rebase --quiet origin master >/dev/null 2>&1
-       } || git fetch --quiet origin >/dev/null
+       } || {
+             git fetch --quiet origin main >/dev/null 2>&1
+             git rebase --quiet origin main >/dev/null 2>&1
+             } || git fetch --quiet origin >/dev/null
 }
 
 # include config files for module

--- a/lib.sh
+++ b/lib.sh
@@ -103,7 +103,6 @@ test ${RRTRACEMINE} -eq 1 -a $# -lt 1 && {
 
 # do a git pull on a module
 function modpull() {
-  local repourl=$1
   test x${RRMODPULL} = xnever && return 0
   local localpull="RRMODPULL_${1//-/_}"
   localpull="${localpull//\./_}"
@@ -115,8 +114,8 @@ function modpull() {
   test -z "${BRANCH_SWITCH}" && {
     git pull --quiet --ff-only --rebase
   } || { git fetch --quiet origin master >/dev/null 2>&1
-         git rebase --quiet origin master >/dev/null
-       }
+         git rebase --quiet origin master >/dev/null 2>&1
+       } || git fetch origin
 }
 
 # include config files for module


### PR DESCRIPTION
```master``` branch needs to be used as variable in future, because newer git servers use ```main```. this should be listed in rrcon.conf 